### PR TITLE
Allow compile on WIN32 without brakes

### DIFF
--- a/APPLICATIONS/PROJECT_CODE/DLLS/LDLL174__RLOOP__LCCM655/localdef.h
+++ b/APPLICATIONS/PROJECT_CODE/DLLS/LDLL174__RLOOP__LCCM655/localdef.h
@@ -165,7 +165,7 @@ RLOOP - FLIGHT CONTROL UNIT - CORE
 		#define C_LOCALDEF__LCCM655__ENABLE_ACCEL							(1U)
 
 		/** Enable the braking subsystems */
-		#define C_LOCALDEF__LCCM655__ENABLE_BRAKES							(1U)
+		#define C_LOCALDEF__LCCM655__ENABLE_BRAKES							(0U)
 
 		/** Enable the throttle control */
 		#define C_LOCALDEF__LCCM655__ENABLE_THROTTLE						(0U)

--- a/FIRMWARE/PROJECT_CODE/LCCM655__RLOOP__FCU_CORE/BRAKES/fcu__brakes__switches.c
+++ b/FIRMWARE/PROJECT_CODE/LCCM655__RLOOP__FCU_CORE/BRAKES/fcu__brakes__switches.c
@@ -411,12 +411,14 @@ void vFCU_BRAKES_SW__Right_SwitchExtend_ISR(void)
  */
 void vFCU_BRAKES_SW_WIN32__Inject_SwitchState(Luint8 u8Brake, Luint8 u8ExtendRetract, Luint8 u8Value)
 {
+	#if C_LOCALDEF__LCCM655__ENABLE_BRAKES == 1U
 	//no index checking on win32
 	sFCU.sBrakes[u8Brake].sLimits[u8ExtendRetract].u8InjectedValue = u8Value;
+	#endif 
 }
 
 
-#endif
+#endif //WIN32
 
 #endif //#if C_LOCALDEF__LCCM655__ENABLE_THIS_MODULE == 1U
 //safetys


### PR DESCRIPTION
Added a #if C_LOCALDEF__LCCM655__ENABLE_BRAKES == 1U guard in fcu__brakes__switches.c to allow compiling with brakes disabled. Also disabled brakes in localdef.h to allow for compiling (see below).

LCCM655 currently does not compile with the brakes enabled due to an unresolved external symbol error for vSIL3_STEPDRIVE_LIMIT__Clear_Limit_ISR(Luint8 u8MotorIndex), defined in COMMON_CODE/MULTICORE/LCCM231__MULTICORE__STEPPER_DRIVE/stepper_drive.h