### PR TITLE
Adding localdef settings to allow the FCU to work with simulators

### DIFF
--- a/APPLICATIONS/PROJECT_CODE/DLLS/LDLL174__RLOOP__LCCM655/localdef.h
+++ b/APPLICATIONS/PROJECT_CODE/DLLS/LDLL174__RLOOP__LCCM655/localdef.h
@@ -153,19 +153,19 @@ RLOOP - FLIGHT CONTROL UNIT - CORE
 		#define C_LOCALDEF__LCCM655__ENABLE_DAQ								(1U)
 
 		/** Enable the OptoNCDT laser interface */
-		#define C_LOCALDEF__LCCM655__ENABLE_LASER_OPTONCDT					(0U)
+		#define C_LOCALDEF__LCCM655__ENABLE_LASER_OPTONCDT					(1U)
 
 		/** Enable the Laser contrast sensors */
-		#define C_LOCALDEF__LCCM655__ENABLE_LASER_CONTRAST					(0U)
+		#define C_LOCALDEF__LCCM655__ENABLE_LASER_CONTRAST					(1U)
 
 		/** Laser Distance Unit */
-		#define C_LOCALDEF__LCCM655__ENABLE_LASER_DISTANCE					(0U)
+		#define C_LOCALDEF__LCCM655__ENABLE_LASER_DISTANCE					(1U)
 
 		/** Enable accel subsystem */
 		#define C_LOCALDEF__LCCM655__ENABLE_ACCEL							(1U)
 
 		/** Enable the braking subsystems */
-		#define C_LOCALDEF__LCCM655__ENABLE_BRAKES							(0U)
+		#define C_LOCALDEF__LCCM655__ENABLE_BRAKES							(1U)
 
 		/** Enable the throttle control */
 		#define C_LOCALDEF__LCCM655__ENABLE_THROTTLE						(0U)


### PR DESCRIPTION
Closing but retaining the settings -- these are the settings that are currently required for the simulator to work (requires certain sensors; no ability from the firmware side to communicate what is disabled. Not a feature request, just an observation.)